### PR TITLE
fix token type conversion error

### DIFF
--- a/gguf_connector/tkn.py
+++ b/gguf_connector/tkn.py
@@ -9,7 +9,7 @@ def get_field(reader, field_name, field_type):
             raise TypeError(f'Bad type for GGUF {field_name} key: expected string, got {field.types!r}')
         return str(field.parts[field.data[-1]], encoding='utf-8')
     elif field_type in [int, float, bool]:
-        return field_type(field.parts[field.data[-1]])
+        return field_type(field.parts[field.data[-1]].item())
     else:
         raise TypeError(f'Unknown field type {field_type}')
 def get_list_field(reader, field_name, field_type):


### PR DESCRIPTION
TypeError: only 0-dimensional arrays can be converted to Python scalars